### PR TITLE
Fix: undefined api prefix in module template unit tests

### DIFF
--- a/plop/module/tests/main.server.test.js
+++ b/plop/module/tests/main.server.test.js
@@ -7,7 +7,7 @@ const User = model('User');
 const { createUser } = require('@helpers/utils');
 
 const express = require('@config/lib/express');
-const { prefix } = require('@config/index');
+const { prefix } = require('@config/index').app;
 
 let app;
 const credentials = {


### PR DESCRIPTION
## Issue
Unit tests fails on newly created module(s).

## Steps to reproduce
1. open devtools.
2. create a new module.
3. run unit tests.

## Expected behavior
Expecting tests to succeed.

## Current behavior
Tests fails with a weird error message, but if you try to debug it you'll see that the `prefix` value is undefined.

## Solution
Fixing `prefix` import.