### PR TITLE
Add nodemailer pooling options

### DIFF
--- a/vendor/users/app.config.js
+++ b/vendor/users/app.config.js
@@ -71,6 +71,9 @@ module.exports = (config) => {
         user: env.get('MAILER_AUTH_USER'),
         pass: env.get('MAILER_AUTH_PASS'),
       },
+      pool: env.get('MAILER_POOL'),
+      maxConnections: env.get('MAILER_MAX_CONNECTIONS'),
+      maxMessages: env.get('MAILER_MAX_MESSAGES'),
     },
   };
 

--- a/vendor/users/variables.meta.json
+++ b/vendor/users/variables.meta.json
@@ -208,6 +208,30 @@
       "type": "password"
     }
   },
+  "MAILER_POOL": {
+    "name": "Enable mailer pooled connection?",
+    "group": "mailer",
+    "defaultValue": false,
+    "schema": {
+      "type": "boolean"
+    }
+  },
+  "MAILER_MAX_CONNECTIONS": {
+    "name": "Mailer max connections",
+    "group": "mailer",
+    "defaultValue": 5,
+    "schema": {
+      "type": "integer"
+    }
+  },
+  "MAILER_MAX_MESSAGES": {
+    "name": "Mailer max messages to be sent using a single connection",
+    "group": "mailer",
+    "defaultValue": 100,
+    "schema": {
+      "type": "integer"
+    }
+  },
   "DEFAULT_GROUPS": {
     "name": "Default groups",
     "defaultValue": "user"


### PR DESCRIPTION
This should fix Mailtrap issues as suggested [here](https://www.dorelljames.com/blog/solving-mailtraps-error-550-too-many-emails-per-second/).

I didn't implement the `rateLimit` option because it's deprecated on the [nodemailer documentation](https://nodemailer.com/smtp/pooled/).

Closes #26.