### PR TITLE
Update emails template header

### DIFF
--- a/vendor/core/views/email.server.view.swig
+++ b/vendor/core/views/email.server.view.swig
@@ -129,7 +129,7 @@
                                     <td bgcolor="#ffffff" width="400" align="right" class="mobile-hide" style="display: none">
                                         <table border="0" cellpadding="0" cellspacing="0">
                                             <tr>
-                                                <td align="right" style="padding: 0 0 5px 0; font-size: 14px; font-family: Arial, sans-serif; color: #666666; text-decoration: none;"><span style="color: #666666; text-decoration: none;">{{ app.name }}</span></td>
+                                                <td align="right" style="padding: 0 0 5px 0; font-size: 14px; font-family: Arial, sans-serif; color: #666666; text-decoration: none;"><span style="color: #666666; text-decoration: none;">{{ app.title }}</span></td>
                                             </tr>
                                         </table>
                                     </td>

--- a/vendor/users/controllers/users/users.profile.server.controller.js
+++ b/vendor/users/controllers/users/users.profile.server.controller.js
@@ -229,10 +229,7 @@ exports.confirm = async function confirm(req, res) {
   return res.format({
     'text/html': () => {
       res.rndr(`${vendor}/users/views/email-confirmed`, {
-        app: {
-          publicAddress: config.app.publicAddress,
-          name: config.app.title,
-        },
+        app: config.app,
         user,
       });
     },


### PR DESCRIPTION
Use `app.title` instead of `app.name` in emails template header since it's not defined in app config, this way we don't need to override app config to pass `name` as a property.

Note: I checked if `app.name` was used anywhere else & didn't found any other matches.