### PR TITLE
Fix deprecations

### DIFF
--- a/config/lib/express.js
+++ b/config/lib/express.js
@@ -11,7 +11,6 @@ const Backend = require('i18next-fs-backend');
 const cookieParser = require('cookie-parser');
 const session = require('express-session');
 const { connection } = require('mongoose');
-const bodyParser = require('body-parser');
 const compress = require('compression');
 const flash = require('connect-flash');
 const nunjucks = require('nunjucks');
@@ -110,8 +109,8 @@ module.exports.initMiddleware = (app) => {
   }
 
   // Request body parsing middleware should be above methodOverride
-  app.use(bodyParser.json({ limit: '4mb', extended: true }));
-  app.use(bodyParser.urlencoded({ limit: '4mb', extended: true }));
+  app.use(express.json({ limit: '4mb', extended: true }));
+  app.use(express.urlencoded({ limit: '4mb', extended: true }));
   app.use(methodOverride());
   // Add the cookie parser and flash middleware
   app.use(cookieParser());

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@sendgrid/mail": "^7.4.4",
     "ajv": "^8.6.0",
     "ajv-errors": "^3.0.0",
-    "body-parser": "^1.19.0",
     "chalk": "^4.1.1",
     "compression": "^1.7.4",
     "connect-flash": "^0.1.1",


### PR DESCRIPTION
`body-parser` module has been deprecated in express 4. Instead we can now directly call bodyParser methods from express module itself.